### PR TITLE
Fix wp_schedule_event cron jobs

### DIFF
--- a/includes/wc-steem-handler.php
+++ b/includes/wc-steem-handler.php
@@ -23,15 +23,15 @@ class WC_Steem_Handler {
 		$instance = __CLASS__;
 
 		if ( ! wp_next_scheduled('wc_steem_update_rates')) {
-			wp_schedule_event(time(), '60min', 'wc_steem_update_rates');
+			wp_schedule_event(time(), 'hourly', 'wc_steem_update_rates');
 		}
 
 		if ( ! wp_next_scheduled('wc_steem_update_orders')) {
-			wp_schedule_event(time(), '5min', 'wc_steem_update_orders');
+			wp_schedule_event(time(), 'hourly', 'wc_steem_update_orders');
 		}
 		
 		if ( ! wp_next_scheduled('wc_steem_send_pending_payment_emails')) {
-			wp_schedule_event(time(), '5min', 'wc_steem_send_pending_payment_emails');
+			wp_schedule_event(time(), 'hourly', 'wc_steem_send_pending_payment_emails');
 		}		
 
 		if (empty(get_option('wc_steem_rates'))) {


### PR DESCRIPTION
the only valid value for parameter of `$recurrence` are `'hourly'`, `'twicedaily'`, and `'daily'`

Reference: https://codex.wordpress.org/Function_Reference/wp_schedule_event